### PR TITLE
fix: check for group which may not be defined

### DIFF
--- a/block_course_contacts.php
+++ b/block_course_contacts.php
@@ -199,7 +199,7 @@ class block_course_contacts extends block_base {
         $userfields = user_picture::fields('u', ['lastaccess', 'phone1', 'description']);
 
         $currentgroup = groups_get_course_group($COURSE, true, false);
-        if ($this->config->group) {
+        if (!empty($this->config->group)) {
             $url = $this->page->url;
             $url->param('id', $courseid);
             $content .= groups_print_course_menu($COURSE, $url, true);


### PR DESCRIPTION
Fixes this issue found: https://github.com/catalyst/moodle-block_course_contacts/commit/b35f64ce2704596a6735409cde4ccf6966cf8673#r67682938