### PR TITLE
WR-424432: Update deprecated user_picture::fields call

### DIFF
--- a/block_course_contacts.php
+++ b/block_course_contacts.php
@@ -196,7 +196,9 @@ class block_course_contacts extends block_base {
         if (isset($this->config->inherit)) {
             $inherit = $this->config->inherit;
         }
-        $userfields = user_picture::fields('u', ['lastaccess', 'phone1', 'description']);
+
+        $userfields = \core_user\fields::for_userpic()->including('lastaccess', 'phone1', 'description');
+        $userfields = $userfields->get_sql('u', false, '', '', false)->selects;
 
         $currentgroup = groups_get_course_group($COURSE, true, false);
         if (!empty($this->config->group)) {


### PR DESCRIPTION
**Description:** The user_picture::fields method has been deprecated since Moodle 3.11, see [MDL-45242](https://tracker.moodle.org/browse/MDL-45242)

**Error occuring:**
```
user_picture::fields() is deprecated. Please use the \core_user\fields API instead.

    line 255 of /lib/outputcomponents.php: call to debugging()
    line 199 of /blocks/course_contacts/block_course_contacts.php: call to user_picture::fields()
    line 337 of /blocks/moodleblock.class.php: call to block_course_contacts->get_content()
    line 231 of /blocks/moodleblock.class.php: call to block_base->formatted_contents()
    line 1222 of /lib/blocklib.php: call to block_base->get_content_for_output()
    line 1280 of /lib/blocklib.php: call to block_manager->create_block_contents()
    line 377 of /lib/blocklib.php: call to block_manager->ensure_content_created()
    line 4101 of /lib/outputrenderers.php: call to block_manager->region_has_content()
    line 75 of /theme/catawesome/layout/drawers.php: call to core_renderer->blocks()
    line 1477 of /lib/outputrenderers.php: call to include()
    line 1403 of /lib/outputrenderers.php: call to core_renderer->render_page_layout()
    line 248 of /course/view.php: call to core_renderer->header()
```

The other site that Catalyst manages on Moodle 4.1 is using the base repository and that uses the below code for getting user fields, and so there was no need to update it during that upgrade:

```
$userfields = 'u.id,u.lastaccess,u.firstname,u.lastname,u.email,u.phone1,u.picture,u.imagealt,
u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.description';
```

This was updated in this repository in commit 61ea95e070d3e2476ebe69a452ba032fedae5261, which is where the now deprecated method was introduced. This commit updates the code with the \core_user\fields API
