### PR TITLE
Include lib.php for hook callback on initial installation

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace block_course_contacts;
+require_once($CFG->dirroot .'/blocks/course_contacts/lib.php');
 
 /**
  * Hook callbacks.


### PR DESCRIPTION
**Description:** Error on site install with latest commit for 4.5:

<img width="594" height="559" alt="image" src="https://github.com/user-attachments/assets/80758fc7-d529-443e-a761-6da78e824b6d" />

Include the `lib.php` file like we do in `envbar`:

https://github.com/catalyst/moodle-local_envbar/blob/MOODLE_405_STABLE/classes/hook_callbacks.php#L21

**Testing instructions:**

1. Clone vanilla Moodle site
2. Add plugin
3. Attempt to install site
4. **Expected:** The install should proceed as normal
5. **Without the patch:** The install will error as above